### PR TITLE
Allow StepUp-Build to create a functional prod tarbal (PART II)

### DIFF
--- a/.github/workflows/build-push-docker-image.yml
+++ b/.github/workflows/build-push-docker-image.yml
@@ -1,13 +1,6 @@
 name: build-push-docker-image
 
-on: 
-  push:
-    branches:
-      - feature/docker_configs
- 
-  workflow_dispatch:
-
-
+on: workflow_dispatch
 
 jobs:
   build-push-docker-image:


### PR DESCRIPTION
Require the Symfony Console to satisfy Monolog in prod mode (https://github.com/symfony/recipes/issues/752)